### PR TITLE
authors/verification: mention how to verify an existing app

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/index.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/index.md
@@ -126,9 +126,9 @@ Use the [OARS website](https://hughsie.github.io/oars/generate.html) to generate
 
 For the quick guidelines for the actual content (descriptions, screenshots), see the Appstream [docs](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).
 
-## Licence
+## License
 
-All appdata must contain a valid SPDX licence. However there isn't an [SPDX licence](https://spdx.org/licenses/) for proprietary software. By convention you should use `LicenseRef-proprietary` in this case.
+All appdata must contain a valid SPDX license. However there isn't an [SPDX license](https://spdx.org/licenses/) for proprietary software. By convention you should use `LicenseRef-proprietary` in this case.
 
 ## Manifest location
 

--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -10,4 +10,4 @@ First, [log in to Flathub](https://www.flathub.org/login). Go to the developer t
 
 ### I'd like to verify my app that someone else already published
 
-The first step is to gain ownership over  your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)
+The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)

--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -7,3 +7,7 @@ Verification is a process by which Flathub can confirm that an app is published 
 ## I'm publishing an app on Flathub. How do I get it verified?
 
 First, [log in to Flathub](https://www.flathub.org/login). Go to the developer tab, if you're not already there. Click the "Developer Settings" button under the app you want to verify. At the top of the page, find the "Setup Verification" section. The instructions there will walk you through the verification process.
+
+### I'd like to verify my app that someone else already published
+
+The first step is to gain ownership over  your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)

--- a/docs/02-for-app-authors/09-verification.md
+++ b/docs/02-for-app-authors/09-verification.md
@@ -10,4 +10,4 @@ First, [log in to Flathub](https://www.flathub.org/login). Go to the developer t
 
 ### I'd like to verify my app that someone else already published
 
-The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](https://docs.flathub.org/docs/for-app-authors/submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)
+The first step is to gain ownership over your app; see [Someone else has put my app on Flathub—what do I do?](submission#someone-else-has-put-my-app-on-flathubwhat-do-i-do)

--- a/docs/02-for-app-authors/12-linter.md
+++ b/docs/02-for-app-authors/12-linter.md
@@ -10,11 +10,11 @@ It's run against all builds send to Flathub, and can be run locally to check you
 Here is a list of linter errors, and whether exceptions may be applied, by default.
 
 | Error                                       | Explanation                                                                  | Exceptions |
-|---------------------------------------------|------------------------------------------------------------------------------|------------|
-| `appid-code-hosting-too-few-components`     | The app id has too few components for code hosting service.                  | No[^a]     |
-| `appid-uses-code-hosting-domain`            | The app id doesn't follow the domain requirements for code hosting services. | No[^a]     |
+| ------------------------------------------- | ---------------------------------------------------------------------------- | ---------- |
+| `appid-code-hosting-too-few-components`     | The app id has too few components for code hosting service.                  | No[^1]     |
+| `appid-uses-code-hosting-domain`            | The app id doesn't follow the domain requirements for code hosting services. | No[^1]     |
 | `finish-args-arbitrary-autostart-access`    | Arbitrary `xdg-autostart` access. Please use the portals.                    | No         |
-| `finish-args-arbitrary-dbus-access`         | Generic D-Bus access is requested.                                           | No[^d]     |
+| `finish-args-arbitrary-dbus-access`         | Generic D-Bus access is requested.                                           | No[^4]     |
 | `finish-args-arbitrary-xdg-cache-access`    | Filesystem permission want `xdg-cache`.                                      | Yes        |
 | `finish-args-arbitrary-xdg-config-access`   | Filesystem permission want `xdg-config`.                                     | Yes        |
 | `finish-args-arbitrary-xdg-data-access`     | Filesystem permission want `xdg-data`.                                       | Yes        |
@@ -25,7 +25,7 @@ Here is a list of linter errors, and whether exceptions may be applied, by defau
 | `finish-args-unnecessary-xdg-cache-access`  | Filesystem permission want `xdg-cache`.                                      | Yes        |
 | `finish-args-unnecessary-xdg-config-access` | Filesystem permission want `xdg-config`.                                     | Yes        |
 | `finish-args-unnecessary-xdg-data-access`   | Filesystem permission want `xdg-data`.                                       | Yes        |
-| `flathub-json-modified-publish-delay`       | Reduced publishing delay in `flathub.json`.                                  | No[^c]     |
+| `flathub-json-modified-publish-delay`       | Reduced publishing delay in `flathub.json`.                                  | No[^3]     |
 | `flathub-json-skip-appstream-check`         | Skipping the appstream check in `flathub.json`                               | Yes        |
 | `module-*-source-git-branch`                | A git source has a branch.                                                   | No         |
 | `module-*-source-git-local-path`            | A git source has a file URL.                                                 | No         |
@@ -33,14 +33,13 @@ Here is a list of linter errors, and whether exceptions may be applied, by defau
 | `module-*-source-git-no-url`                | A git source has no URL specified.                                           | No         |
 | `module-*-source-git-url-not-http`          | A git source URL is not http nor https.                                      | No         |
 | `toplevel-cleanup-debug`                    | `/lib/debug` is in the top level `cleanup` rule.                             | No         |
-| `toplevel-no-command`                       | The `command` property is missing.                                           | No[^b]     |
+| `toplevel-no-command`                       | The `command` property is missing.                                           | No[^2]     |
 | `toplevel-no-modules`                       | There are no modules in the manifest.                                        | No         |
 
-
-[^a]: Unless the package existed before the linter.
-[^b]: Exception needed for BaseApps where a default command may not make sense.
-[^c]: Granted for `extra-data`.
-[^d]: Exception only for tools that reequires D-Bus access and for which the names are not predictable ; this includes D-Bus tools and IDEs. In general it isn't allowed.
+[^1]: Unless the package existed before the linter.
+[^2]: Exception needed for BaseApps where a default command may not make sense.
+[^3]: Granted for `extra-data`.
+[^4]: Exception only for tools that reequires D-Bus access and for which the names are not predictable ; this includes D-Bus tools and IDEs. In general it isn't allowed.
 
 ## Exceptions
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: GPTBot
+Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,5 @@
 User-agent: GPTBot
 Disallow: /
+
+User-agent: CCBot
+Disallow: /


### PR DESCRIPTION
This is useful documentation for when a third-party/community member has uploaded an app, and then the original developer wants to get it verified; we need to point them to how to gain ownership as a first step.